### PR TITLE
Introduce docker-compose setup for dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.7
+
+WORKDIR /ockovani-covid
+COPY requirements.txt ./
+# create virtualenv & install requirements
+RUN python3 -m venv venv3 && venv3/bin/pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENTRYPOINT ["/ockovani-covid/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM python:3.7
-
-WORKDIR /ockovani-covid
-COPY requirements.txt ./
-# create virtualenv & install requirements
-RUN python3 -m venv venv3 && venv3/bin/pip install --no-cache-dir -r requirements.txt
-COPY . .
-ENTRYPOINT ["/ockovani-covid/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Aplikace se skládá z modulu fetcher, pak samotného webu a skriptu, který web
 
 # How to run it [ENG]
 
+## Quick start with docker-compose
+
+`docker-compose up`
+
+The development server (default flask one for the moment) will start at port `5000`,
+you can access the deployment at `http://localhost:5000/ockovani-covid`.
+
 ## Installation
 
 ### Virtual environment
@@ -45,7 +52,7 @@ flask run
 ## Update
 1. update config.ini
 1. activate venv `source venv/bin/activate`
-1. execute database migration if needed `flask db upgrade`   
+1. execute database migration if needed `flask db upgrade`
 1. fetch data `flask fetch-all &`
 1. restart or start webserver if needed `flask run --host=0.0.0.0 --port=5000`
 1. publish website and CSV's `bash tools/manual_publish.sh`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Pro získávání dat využívá metody scrapingu. Vzhledem k tomu, že jsou dat
 Aplikace se skládá z modulu fetcher, pak samotného webu a skriptu, který web stáhne a publikuje na github pages. Tento krok je realizován proto, že nechceme vystavovat veřejně aplikační server a chceme přenést zátěž na prostředky Githubu. Navíc jde o statické stránky, u kterých není problém obsloužit mnoho tisíc lidí současně.
 
 
+## Important to know
+In order to get the data a scraper is run against the reservation system. As long as the the sample data is accessible through github pages and the development server, **please
+do not run the scraper locally, this might cause additional stress to the rezervation system!**
+
 # How to run it [ENG]
 
 ## Quick start with docker-compose
@@ -25,7 +29,7 @@ Aplikace se skládá z modulu fetcher, pak samotného webu a skriptu, který web
 The development server (default flask one for the moment) will start at port `5000`,
 you can access the deployment at `http://localhost:5000/ockovani-covid`.
 
-## Installation
+## Installation without docker-compose
 
 ### Virtual environment
 

--- a/config.py
+++ b/config.py
@@ -3,5 +3,5 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 
 class Config(object):
-    SQLALCHEMY_DATABASE_URI = 'postgresql://ockovani:ockovani@localhost:5432/ockovani'
+    SQLALCHEMY_DATABASE_URI = 'postgresql://ockovani:ockovani@db:5432/ockovani'
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.3'
+
+services:
+  db:
+    image: postgres
+    volumes:
+      - db_data:/var/lib/postgresql
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: "ockovani"
+      POSTGRES_DB: "ockovani"
+      POSTGRES_USER: "ockovani"
+  app:
+    build:
+      context: .
+    links:
+      - db:db
+    depends_on:
+      - db
+    environment:
+      FLASK_ENV: "development"
+    ports:
+      - "5000:5000"
+
+volumes:
+  db_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,17 @@ services:
     image: postgres
     volumes:
       - db_data:/var/lib/postgresql
+      - ./dockerize/ockovani-2103020753.sql:/docker-entrypoint-initdb.d/init.sql
     restart: always
     environment:
       POSTGRES_PASSWORD: "ockovani"
-      POSTGRES_DB: "ockovani"
       POSTGRES_USER: "ockovani"
+      # NOTE(ivasilev) If a backup.sql mapped to docker-entrypoint-initdb.d already creates the db then POSTGRES_DB should be removed. This currently works as L23 of ockovani-2103020753.sql is commented out not to cause conflicts.
+      POSTGRES_DB: "ockovani"
   app:
     build:
       context: .
+      dockerfile: dockerize/Dockerfile
     links:
       - db:db
     depends_on:

--- a/dockerize/Dockerfile
+++ b/dockerize/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.7
+
+WORKDIR /ockovani-covid
+COPY requirements.txt ./
+# create virtualenv & install requirements
+RUN python3 -m venv venv3 && venv3/bin/pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENTRYPOINT ["/ockovani-covid/dockerize/entrypoint.sh"]

--- a/dockerize/entrypoint.sh
+++ b/dockerize/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# run migrations
+venv3/bin/flask db upgrade
+venv3/bin/flask run --host 0.0.0.0 --port 5000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-venv3/bin/flask db upgrade
-venv3/bin/flask run --host 0.0.0.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+venv3/bin/flask db upgrade
+venv3/bin/flask run --host 0.0.0.0


### PR DESCRIPTION
A single docker-compose up command brings up the deployment.
Not suitable for production as development flask server is used,
should switch to nginx (or any other real webserver) to be prod-ready.

[Still to be done before PR merge] Fill in the DB with default data while
not violating the "don't scrape the real system" policy.