### PR TITLE
Move last website build time to footer

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -77,7 +77,6 @@
     <div class="alert alert-warning alert-dismissible fade show row" role="alert">
         <p class="mb-0">
             Poslední aktualizace zdrojových dat:&nbsp;<strong>{{ last_update }}</strong>.
-            Poslední aktualizace webu:&nbsp;<strong>{{ now }}</strong>.
         </p>
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
@@ -92,6 +91,7 @@
 <div class="footer text-center p-3 bg-light mt-4">
     <p class="mb-1">
         Vznik: 16. 01. 2021.
+        Poslední aktualizace webu:&nbsp;{{ now }}.
         Data na tomto webu pochází z <a href="https://onemocneni-aktualne.mzcr.cz/api/v2/covid-19" target="_blank">opendat Ministerstva zdravotnictví ČR</a>.
     </p>
     <p class="mb-1 font-italic">


### PR DESCRIPTION
I wouldn't say that this information is relevant to average user and they wouldn't understand difference between it and dataset fetch time.