### PR TITLE
Fix hidden text in hover labels.

### DIFF
--- a/app/templates/macros/graphs/fronta.html
+++ b/app/templates/macros/graphs/fronta.html
@@ -30,6 +30,7 @@
             mode: "lines+markers",
             type: "scatter",
             name: "Čekající na rezervaci termínu",
+            hovertemplate: "%{y}"
         }
 
         const rezervace_1 = {
@@ -38,6 +39,7 @@
             mode: "lines+markers",
             type: "scatter",
             name: "Čekající na očkování 1. dávkou",
+            hovertemplate: "%{y}"
         }
 
         const rezervace_2 = {
@@ -46,6 +48,7 @@
             mode: "lines+markers",
             type: "scatter",
             name: "Čekající na očkování 2. dávkou",
+            hovertemplate: "%{y}"
         }
 
         const layout = {

--- a/app/templates/macros/graphs/ockovani.html
+++ b/app/templates/macros/graphs/ockovani.html
@@ -27,6 +27,7 @@
             mode: "lines+markers",
             type: "scatter",
             name: "Očkováno",
+            hovertemplate: "%{y}"
         }
 
         const ockovane_1 = {
@@ -36,6 +37,7 @@
             type: "scatter",
             name: "Očkováno 1. dávkou",
             visible: "legendonly",
+            hovertemplate: "%{y}"
         }
 
         const ockovane_2 = {
@@ -45,6 +47,7 @@
             type: "scatter",
             name: "Očkováno 2. dávkou",
             visible: "legendonly",
+            hovertemplate: "%{y}"
         }
         {% endif %}
 
@@ -56,6 +59,7 @@
             name: "Použito dávek",
             {% if 'ockovane' in data %}
             visible: "legendonly",
+            hovertemplate: "%{y}"
             {% endif %}
         }
 
@@ -65,6 +69,7 @@
             mode: "lines+markers",
             type: "scatter",
             name: "Rezervace",
+            hovertemplate: "%{y}"
         }
 
         const rezervace_1 = {
@@ -74,6 +79,7 @@
             type: "scatter",
             name: "Rezervace na 1. dávku",
             visible: "legendonly",
+            hovertemplate: "%{y}"
         }
 
         const rezervace_2 = {
@@ -83,6 +89,7 @@
             type: "scatter",
             name: "Rezervace na 2. dávku",
             visible: "legendonly",
+            hovertemplate: "%{y}"
         }
 
         const kapacita = {
@@ -91,6 +98,7 @@
             mode: "lines+markers",
             type: "scatter",
             name: "Maximální kapacita",
+            hovertemplate: "%{y}"
         }
 
         const kapacita_1 = {
@@ -100,6 +108,7 @@
             type: "scatter",
             name: "Maximální kapacita pro 1. dávky",
             visible: "legendonly",
+            hovertemplate: "%{y}"
         }
 
         const kapacita_2 = {
@@ -109,6 +118,7 @@
             type: "scatter",
             name: "Maximální kapacita pro 2. dávky",
             visible: "legendonly",
+            hovertemplate: "%{y}"
         }
 
         const layout = {

--- a/app/templates/macros/graphs/ockovani_celkem.html
+++ b/app/templates/macros/graphs/ockovani_celkem.html
@@ -8,6 +8,7 @@
             mode: "lines",
             type: "scatter",
             name: "Očkovaní (alespoň jedna dávka)",
+            hovertemplate: "%{y}"
         }
 
         const ockovani_plne = {
@@ -16,6 +17,7 @@
             mode: "lines",
             type: "scatter",
             name: "Plně očkovaní (všechny potřebné dávky)",
+            hovertemplate: "%{y}"
         }
 
         const layout = {

--- a/app/templates/macros/graphs/registrace.html
+++ b/app/templates/macros/graphs/registrace.html
@@ -26,6 +26,7 @@
             mode: "lines+markers",
             type: "scatter",
             name: "Nové registrace",
+            hovertemplate: "%{y}"
         }
 
         const rezervace = {
@@ -34,6 +35,7 @@
             mode: "lines+markers",
             type: "scatter",
             name: "Nové rezervace",
+            hovertemplate: "%{y}"
         }
 
         const layout = {


### PR DESCRIPTION
Regarding the issues with hidden trace names in the hover labels - it was needed to specify the hovertemplate for every trace and afterwards the name of the trace is not hidden anymore. In case you would like to change the name of the trace in the hover label use the <extra>xxxx</extra> tag in the hovertemplate to modify the trace name before the y axis value in the hover label.

Link to the issue regarding customization of trace name in hover label:
https://community.plotly.com/t/remove-trace-0-next-to-hover/33731