### PR TITLE
ignore accents in search

### DIFF
--- a/app/templates/macros/tables/prehled_mist.html
+++ b/app/templates/macros/tables/prehled_mist.html
@@ -108,18 +108,20 @@
 </div>
 
 <script>
+    const stripAccents = x => x.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
     function filterChanged() {
-        const searchValue = $("#centers-searchbox").val().toLowerCase();
+        const searchValue = stripAccents($("#centers-searchbox").val().toLowerCase());
         const activeValue = $("#centers-active")[0].checked;
         const barrierfreeValue = $("#centers-barrierfree")[0].checked;
         const selfPaidValue = $("#centers-selfpaid")[0].checked;
         const selfPaidString = "samopl"
 
         $("#centers-table tbody tr").filter(function () {
+            const normalized = stripAccents($(this).text().toLowerCase());
             $(this).toggle(
-                $(this).text().toLowerCase().indexOf(searchValue) > -1
-                && ((selfPaidValue && $(this).text().toLowerCase().indexOf(selfPaidString) > -1) || (
-                    !selfPaidValue && $(this).text().toLowerCase().indexOf(selfPaidString) === -1))
+                normalized.indexOf(searchValue) > -1
+                && ((selfPaidValue && normalized.indexOf(selfPaidString) > -1) || (
+                    !selfPaidValue && normalized.indexOf(selfPaidString) === -1))
                 && (!activeValue || $(this)[0].dataset.active === 'True')
                 && (!barrierfreeValue || $(this)[0].dataset.barrierfree === 'True')
             )

--- a/app/templates/macros/tables/prehled_praktici.html
+++ b/app/templates/macros/tables/prehled_praktici.html
@@ -63,16 +63,17 @@
 </p>
 
 <script>
+    const stripAccents = x => x.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
     $(document).ready(function(){
-      $("#doctors-searchbox").on("keyup", function() {
-        var value = $(this).val().toLowerCase();
-        $("#doctors-table tbody tr").filter(function() {
-          $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+        $("#doctors-searchbox").on("keyup", function() {
+            var value = stripAccents($(this).val().toLowerCase());
+            $("#doctors-table tbody tr").filter(function() {
+                $(this).toggle(stripAccents($(this).text().toLowerCase()).indexOf(value) > -1)
+            });
+            $("#doctors-table tbody tr:visible").each(function (index) {
+                $(this).css("background-color", !!(index & 1) ? "rgba(0,0,0,0)"  : "rgba(0,0,0,.05)");
+            });
         });
-        $("#doctors-table tbody tr:visible").each(function (index) {
-            $(this).css("background-color", !!(index & 1) ? "rgba(0,0,0,0)"  : "rgba(0,0,0,.05)");
-        });
-      });
     });
 </script>
 {%- endmacro %}


### PR DESCRIPTION
Pokaždý na webu hledám něco jako "národní očkovací centrum", dám do hledání "narodni"... a nenajde to. Tak jsem to zkusil implementovat. Pár poznámek:

- je to jen na očkovacích místech, ne u praktiků, protože jsem neviděl, jestli tam nemáš nějakou sdílenou sadu skriptů (byť copy paste by tu asi nevadil)
- používám `String.normalize`, kterej má [celkem dobrou podporu](https://caniuse.com/mdn-javascript_builtins_string_normalize), ale odřezává IE11 (podobně jako Arrow functions, který jsem použil), tak nevim, jak to ovlivňuje tvoji cílovku
- mohl jsem tam udělat `const normalize = x => stripAccents(x.toLowerCase())`, aby to bylo jednotný... případně narvat `stripAccents` do `String.prototype`... ale rozhodl jsem se to dál nekomplikovat, tak snad cajk.