### PR TITLE
Mark centers with reservatic API error

### DIFF
--- a/app/fetcher/reservations_api_fetcher.py
+++ b/app/fetcher/reservations_api_fetcher.py
@@ -65,12 +65,16 @@ class ReservationsApiFetcher(Fetcher):
 
             if r.status_code == 404:
                 # Place not found
+                ocm.reservatic_api_nenalezeno = True
+                db.session.merge(ocm)
                 not_found += 1
                 continue
 
             response_data = r.json()
 
             if len(response_data) == 0:
+                ocm.reservatic_api_prazdne = True
+                db.session.merge(ocm)
                 empty += 1
                 continue
 

--- a/app/models.py
+++ b/app/models.py
@@ -151,6 +151,8 @@ class OckovaciMisto(db.Model):
     nrpzs_kod = Column(Unicode, index=True)
     minimalni_kapacita = Column(Integer)
     bezbarierovy_pristup = Column(Boolean)
+    reservatic_api_nenalezeno = Column(Boolean)
+    reservatic_api_prazdne = Column(Boolean)
 
     okres = relationship("Okres", back_populates="ockovaci_mista")
     ockovaci_misto_detail = relationship("OckovaciMistoDetail", uselist=False, lazy='joined')


### PR DESCRIPTION
The idea was to:

1. find if the centers which returns errors have something in common (like disabled, ...) - but all centers without registration are marked as disabled
2. find if we can somehow filter active centers without registration - but Hlavni nadrazi is active and it returns 404, because it uses only J&J and doesn't need any reservations